### PR TITLE
fix unicode error in getWindowTitle on windows

### DIFF
--- a/src/win32/window_manager.cc
+++ b/src/win32/window_manager.cc
@@ -38,16 +38,16 @@ MMRect getWindowRect(const WindowHandle windowHandle) {
     return MMRectMake(0, 0, 0, 0);
 }
 
-std::string getWindowTitle(const WindowHandle windowHandle) {
+char16_t* getWindowTitle(const WindowHandle windowHandle) {
     HWND hWnd = reinterpret_cast<HWND>(windowHandle);
     if (IsWindow(hWnd)) {
-        auto BUFFER_SIZE = GetWindowTextLength(hWnd) + 1;
+        auto BUFFER_SIZE = GetWindowTextLengthW(hWnd) + 1;
         if (BUFFER_SIZE) {
-            LPSTR windowTitle = new CHAR[BUFFER_SIZE];
-            if (GetWindowText(hWnd, windowTitle, BUFFER_SIZE)) {
-                return std::string(windowTitle);
+            wchar_t* windowTitle = new wchar_t[BUFFER_SIZE + 2];
+            if (GetWindowTextW(hWnd, windowTitle, BUFFER_SIZE)) {
+                return (char16_t*)windowTitle;
             }
         }
     }
-    return "";
+    return (char16_t*)L"";
 }

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -24,7 +24,7 @@ WindowHandle getActiveWindow();
  * `getWindowTitle` returns an std::string holding the window title for a window adressed via its window handle.
  * The respective window handle may be aquired via `getWindows` or `getActiveWindow`
  */
-std::string getWindowTitle(const WindowHandle windowHandle);
+char16_t* getWindowTitle(const WindowHandle windowHandle);
 /**
  * `getWindowRect` returns an MMRect struct representing the window's size and position.
  * Windows are adressed via their window handle.


### PR DESCRIPTION
When I use `getWindowTitle` I found that `getWindowTitle` does not support Unicode on Windows. I try to fix it.

fix result: 
1. First use Chrome to set the window title
![N1](https://user-images.githubusercontent.com/894004/149917978-064ebca0-fb56-4f1c-8ced-3298c824fe4b.png)
2. The test string is `こんにちは⌛你好⌛สวัสดีครับ⌛안녕하세`
3. Write the test code in `test` folder
````javascript
const libnut = require("..");

const hWnds = libnut.getWindows();

for(const hWnd of hWnds) {
	const title = libnut.getWindowTitle(hWnd);

	if(title && title.endsWith(' - Google Chrome')) {
		console.log(hWnd, title);

		break;
	}
}
````
4. Test Result
  - without fix:
![N2](https://user-images.githubusercontent.com/894004/149918756-10923f85-1cc6-414a-b4e4-4f39fa109871.png)
  - with fix:
![N3](https://user-images.githubusercontent.com/894004/149918778-48b33259-8c6c-4bfb-b260-2395d1cdccc2.png)

_I haven't done much testing and don't know if this fix is appropriate.
But I hope to provide you with ideas for solving Unicode support :)_