### PR TITLE
fix mouse

### DIFF
--- a/src/win32/mouse.c
+++ b/src/win32/mouse.c
@@ -34,7 +34,7 @@ static int32_t DEFAULT_DOUBLE_CLICK_INTERVAL_MS = 200;
 
 MMPoint CalculateAbsoluteCoordinates(MMPoint point) {
 	MMSize displaySize = getMainDisplaySize();
-	return MMPointMake(((float) point.x / displaySize.width) * ABSOLUTE_COORD_CONST,  ((float) point.y / displaySize.height) * ABSOLUTE_COORD_CONST);
+	return MMPointMake((ABSOLUTE_COORD_CONST * point.x / displaySize.width) + (point.x < 0 ? -1 : 1) ,  (ABSOLUTE_COORD_CONST * point.y / displaySize.height) + (point.y < 0 ? -1 : 1));
 }
 
 /**


### PR DESCRIPTION
## Description

I experienced the issue described in [#126](https://github.com/nut-tree/libnut-core/issues/126). I tested out the solution to the issue (listed in the original post) and confirmed that the provided change resolved the problem for me.



###  Steps to reproduce:

It's extremely easy to reproduce the bug, and notably, the x coordinate moves as well. To reproduce, run the following code:

```
function loop() {
 try {
   const mp = libnut.getMousePos()
   libnut.moveMouse(mp.x, mp.y)
   console.log('loop', mp)
   loop()
 } catch (e) {
   console.log('loop error', e)
 }
}

loop()
```

### Expected:

The cursor should stay in the same position.

### Result:

The cursor moves to "breakpoints" where it stops; if the cursor is moved from a "breakpoint," it will begin creeping towards the next one. 

### Comments 
The solution worked well in testing, however, if this solution does not work for the repo, is there another solution that could be implemented? 

I hope all is well @s1hofmann & thank you for maintaining! 