### PR TITLE
adds support for fn as a modifier key

### DIFF
--- a/src/keypress.h
+++ b/src/keypress.h
@@ -20,7 +20,8 @@ extern "C"
 		MOD_META = kCGEventFlagMaskCommand,
 		MOD_ALT = kCGEventFlagMaskAlternate,
 		MOD_CONTROL = kCGEventFlagMaskControl,
-		MOD_SHIFT = kCGEventFlagMaskShift
+		MOD_SHIFT = kCGEventFlagMaskShift,
+		MOD_FUNCTION = kCGEventFlagMaskSecondaryFn
 	} MMKeyFlags;
 
 	extern MMKeyFlags flagBuffer;
@@ -32,7 +33,8 @@ extern "C"
 		MOD_META = Mod4Mask,
 		MOD_ALT = Mod1Mask,
 		MOD_CONTROL = ControlMask,
-		MOD_SHIFT = ShiftMask
+		MOD_SHIFT = ShiftMask,
+		MOD_FUNCTION = 0
 	};
 
 	typedef unsigned int MMKeyFlags;
@@ -45,7 +47,8 @@ extern "C"
 		/* MOD_ALT = 0,
 		MOD_CONTROL = 0,
 		MOD_SHIFT = 0, */
-		MOD_META = MOD_WIN
+		MOD_META = MOD_WIN,
+		MOD_FUNCTION = 0
 	};
 
 	typedef unsigned int MMKeyFlags;

--- a/src/macos/keypress.c
+++ b/src/macos/keypress.c
@@ -67,6 +67,9 @@ void toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags) {
     if (code == K_SHIFT || code == K_RIGHTSHIFT) {
       flags |= MOD_SHIFT;
     }
+    if (code == K_FUNCTION) {
+      flags |= MOD_FUNCTION;
+    }
 
     MMKeyFlags activeKeyFlags;
     if (down) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -365,6 +365,8 @@ int CheckKeyFlags(std::string &flagString, MMKeyFlags *flags) {
         *flags = MOD_CONTROL;
     } else if (flagString == "shift" || flagString == "right_shift") {
         *flags = MOD_SHIFT;
+    } else if (flagString == "fn") {
+        *flags = MOD_FUNCTION;
     } else if (flagString == "none") {
         *flags = MOD_NONE;
     } else {


### PR DESCRIPTION
The Fn key (at least on macOS) is actually a modifier key, so this commit adds support for it to be used as such...the only thing is...is that it doesn't actually seem to operate the same way as on the physical keyboard. For example, "Fn Backspace" should send "Delete", but it ends up just sending "Backspace" again. Based on my testing, "Fn" is being seen as a modifier, but it doesn't actually seem to be modifying. I'm not sure if this is the expected behavior since there are, indeed, separate keycodes for Backspace and Delete.

I initially came down this path hoping to get around the missing "Enter" keycode I implemented in #168. I was hoping I could just get around it by sending Fn + Return, but it didn't work. Based on how the other modifier keys are implemented, I believe I have implemented Function correctly, but have not seen the expected results.

Looking for some guidance... thanks!